### PR TITLE
Don't use internal class

### DIFF
--- a/src/main/java/com/okta/tools/authentication/CookieManager.java
+++ b/src/main/java/com/okta/tools/authentication/CookieManager.java
@@ -27,8 +27,7 @@ import java.util.Map;
  * Adaptor for {@link com.sun.webkit.network.CookieManager} that stores cookies
  */
 public final class CookieManager extends CookieHandler {
-    // internal class use is intentional: we need RFC6265 cookies which this OpenJFX class handles
-    private final CookieHandler cookieHandler = new com.sun.webkit.network.CookieManager();
+    private final CookieHandler cookieHandler = CookieHandler.getDefault();
     private final CookieHelper cookieHelper;
 
     public CookieManager(CookieHelper cookieHelper) {


### PR DESCRIPTION
Use `CookieHandler.getDefault()` instead of the `com.sun.webkit.network.CookieManager` internal class.

`CookieHandler.getDefault()` returns an instance of `com.sun.webkit.network.CookieManager` so this change results in the same behavior.

This change fixes this error at runtime:
```
Exception in thread "JavaFX Application Thread" java.lang.IllegalAccessError: class com.okta.tools.authentication.CookieManager (in unnamed module @0x1ce24091) cannot access class com.sun.webkit.network.CookieManager (in module javafx.web) because module javafx.web does not export com.sun.webkit.network to unnamed module @0x1ce24091
```

Problem Statement
-----------------



Solution
--------


