### PR TITLE
Fix retrieval of latest release tag url

### DIFF
--- a/bin/install.sh
+++ b/bin/install.sh
@@ -80,7 +80,7 @@ PREFIX="$(cd -P -- "${PREFIX}" && pwd)"
 echo "Installing into ${PREFIX}" | sed "s#$HOME#~#g"
 
 mkdir -p ${PREFIX}
-releaseUrl=$(curl --head --silent ${repo_url}/releases/latest | grep -i "Location:" | cut -c11-)
+releaseUrl=$(curl -sLI ${repo_url}/releases/latest | grep -e "location:.*tag" | cut -c11-)
 releaseTag=$(echo $releaseUrl | awk 'BEGIN{FS="/"}{print $8}' | tr -d '\r')
 url=${repo_url}/releases/download/${releaseTag}/okta-aws-cli-${releaseTag:1}.jar
 dest=${PREFIX}/$(basename ${url})


### PR DESCRIPTION
Problem Statement
-----------------

GitHub has introduced a redirect to the `/releases/latest` path on all repositories.

Solution
--------

Follow the path, and only select the relevant url.