### PR TITLE
Support okta idp factor

### DIFF
--- a/Readme.MD
+++ b/Readme.MD
@@ -158,6 +158,8 @@ Here is the list of parameters that can be environment variables or settings in 
   - ```OKTA_AWS_ROLE_TO_ASSUME``` is the IAM Role ARN to use. If present will try to match okta account's retrieved role list and use it. Will still prompt if no match found. (ex: **arn:aws:iam::123456789012:role/EC2-Admins**)
   - ```OKTA_STS_DURATION``` is the duration the role will be assumed, in seconds. The maximum session duration allowed by AWS is 12 hours and this needs to be set on the role as well.  Defaults to 1hr.
   - ```OKTA_MFA_CHOICE``` is the provider and factor type to use if prompted for MFA.  Example: ```OKTA.push```. See [Factors documentation](https://developer.okta.com/docs/api/resources/factors#factor-type) for values. (default: use single factor or prompt user to select from usable factors).
+  - ```OKTA_IGNORE_SAML_REQ_CONTAIN``` is an optional parameter that allow users to ignore pasring SAML requests, where the URL contains a specific string . This is relevant when using the custom IdP factor, which adds addtional SAML requests to users authentication flow. See [Custom IdP Factor Authentication
+](https://help.okta.com/en/prod/Content/Topics/Security/MFA_Custom_Factor.htm) for more details. Defaults to an empty string.
   
   - **Obtaining the AWS app url**
     - Navigate to the ```Admin Dashboard``` of you Okta organization

--- a/src/main/java/com/okta/tools/OktaAwsCliEnvironment.java
+++ b/src/main/java/com/okta/tools/OktaAwsCliEnvironment.java
@@ -32,16 +32,18 @@ public class OktaAwsCliEnvironment {
     public final String oktaMfaChoice;
     public boolean oktaEnvMode;
 
+    public String oktaIgnoreSaml;
+
     public OktaAwsCliEnvironment()
     {
-        this(false, null, null, null, null, null, null, null, 0, null, null, false);
+        this(false, null, null, null, null, null, null, null, 0, null, null, false, null);
     }
 
     public OktaAwsCliEnvironment(boolean browserAuth, String oktaOrg,
                                  String oktaUsername, InterruptibleSupplier<String> oktaPassword, String oktaCookiesPath,
                                  String oktaProfile, String oktaAwsAppUrl, String awsRoleToAssume,
                                  int stsDuration, String awsRegion,
-                                 String oktaMfaChoice, boolean oktaEnvMode) {
+                                 String oktaMfaChoice, boolean oktaEnvMode, String oktaIgnoreSaml) {
         this.browserAuth = browserAuth;
         this.oktaOrg = oktaOrg;
         this.oktaUsername = oktaUsername;
@@ -54,6 +56,7 @@ public class OktaAwsCliEnvironment {
         this.awsRegion = awsRegion;
         this.oktaMfaChoice = oktaMfaChoice;
         this.oktaEnvMode = oktaEnvMode;
+        this.oktaIgnoreSaml = oktaIgnoreSaml;
     }
 
 }

--- a/src/main/java/com/okta/tools/OktaAwsConfig.java
+++ b/src/main/java/com/okta/tools/OktaAwsConfig.java
@@ -76,7 +76,8 @@ final class OktaAwsConfig {
                 getStsDurationOrDefault(getEnvOrConfig(properties, "OKTA_STS_DURATION")),
                 getAwsRegionOrDefault(getEnvOrConfig(properties, "OKTA_AWS_REGION")),
                 getEnvOrConfig(properties, "OKTA_MFA_CHOICE"),
-                Boolean.parseBoolean(getEnvOrConfig(properties, "OKTA_ENV_MODE"))
+                Boolean.parseBoolean(getEnvOrConfig(properties, "OKTA_ENV_MODE")),
+                getEnvOrConfig(properties, "OKTA_IGNORE_SAML_REQ_CONTAIN")
         );
     }
 

--- a/src/main/java/com/okta/tools/authentication/BrowserAuthentication.java
+++ b/src/main/java/com/okta/tools/authentication/BrowserAuthentication.java
@@ -83,7 +83,7 @@ public final class BrowserAuthentication extends Application {
         webEngine.locationProperty()
                 .addListener((ov, oldLocation, newLocation) -> {
                     if (webEngine.getDocument() != null) {
-                        checkForAwsSamlSignon(stage, webEngine);
+                        checkForAwsSamlSignon(stage, webEngine, newLocation);
                         stage.setTitle(webEngine.getLocation());
                     }
                 });
@@ -107,16 +107,19 @@ public final class BrowserAuthentication extends Application {
         java.net.CookieHandler.getDefault().put(uri, headers);
     }
 
-    private void checkForAwsSamlSignon(Stage stage, WebEngine webEngine) {
-        String samlResponseForAws = getSamlResponseForAws(webEngine.getDocument());
+    private void checkForAwsSamlSignon(Stage stage, WebEngine webEngine, String newLocation) {
+        String samlResponseForAws = getSamlResponseForAws(webEngine.getDocument(), newLocation);
         if (samlResponseForAws != null) {
             finishAuthentication(stage, samlResponseForAws);
         }
     }
 
-    private String getSamlResponseForAws(Document document) {
+    private String getSamlResponseForAws(Document document, String newLocation) {
         Node awsStsSamlForm = getAwsStsSamlForm(document);
         if (awsStsSamlForm == null) return null;
+        if (environment.oktaIgnoreSaml != null) {
+            if (newLocation.contains(environment.oktaIgnoreSaml))return null;
+        }
         return getSamlResponseFromForm(awsStsSamlForm);
     }
 

--- a/src/test/java/com/okta/tools/RoleHelperTest.java
+++ b/src/test/java/com/okta/tools/RoleHelperTest.java
@@ -32,7 +32,7 @@ class RoleHelperTest {
 
     @Test
     void main() throws Exception {
-        OktaAwsCliEnvironment environment = new OktaAwsCliEnvironment(false, null, null, null, null, null, "https://acmecorp.oktapreview.com/home/amazon_aws/0oa5zrwfs815KJmVF0h7/137", null, 0, null, null, false);
+        OktaAwsCliEnvironment environment = new OktaAwsCliEnvironment(false, null, null, null, null, null, "https://acmecorp.oktapreview.com/home/amazon_aws/0oa5zrwfs815KJmVF0h7/137", null, 0, null, null, false, null);
         RoleHelper roleHelper = new RoleHelper(environment);
         List<AccountOption> availableRoles = roleHelper.getAvailableRoles(EXAMPLE_SAML_RESPONSE);
         assertEquals(singletonList(

--- a/src/test/java/com/okta/tools/authentication/OktaFactorSelectorTest.java
+++ b/src/test/java/com/okta/tools/authentication/OktaFactorSelectorTest.java
@@ -34,7 +34,7 @@ class OktaFactorSelectorTest {
     @BeforeEach
     void setUp() {
         String oktaMfaChoice = "OKTA.push";
-        OktaAwsCliEnvironment environment = new OktaAwsCliEnvironment(false, null, null, null, null, null, null, null, 0, null, oktaMfaChoice, false);
+        OktaAwsCliEnvironment environment = new OktaAwsCliEnvironment(false, null, null, null, null, null, null, null, 0, null, oktaMfaChoice, false, null);
         MenuHelper menuHelper = mock(MenuHelper.class);
         oktaFactorSelector = new OktaFactorSelectorImpl(environment, menuHelper);
         primaryAuthResponse = mock(JSONObject.class);

--- a/src/test/java/com/okta/tools/helpers/ProfileHelperTest.java
+++ b/src/test/java/com/okta/tools/helpers/ProfileHelperTest.java
@@ -51,7 +51,7 @@ class ProfileHelperTest {
     @BeforeEach
     void setUp() {
         credentialsHelper = mock(CredentialsHelper.class);
-        environment = new OktaAwsCliEnvironment(false, null, null, null, null, null, null, null, 0, fakeAwsRegion, null, false);
+        environment = new OktaAwsCliEnvironment(false, null, null, null, null, null, null, null, 0, fakeAwsRegion, null, false, null);
         profileHelper = new ProfileHelper(credentialsHelper, environment);
         assumeRoleWithSAMLResult = new AssumeRoleWithSAMLResult();
         Credentials credentials = new Credentials(fakeAccessKey, fakeSecretKey, fakeSessionToken, fakeExpiryDate);

--- a/src/test/java/com/okta/tools/saml/OktaSamlTest.java
+++ b/src/test/java/com/okta/tools/saml/OktaSamlTest.java
@@ -34,7 +34,7 @@ class OktaSamlTest {
 
     @Test
     void getSamlResponse() throws IOException, InterruptedException {
-        OktaAwsCliEnvironment environment = new OktaAwsCliEnvironment(false, null, null, null, null, null, "https://acmecorp.oktapreview.com/home/amazon_aws/0oa5zrwfs815KJmVF0h7/137", null, 0, null, null, false);
+        OktaAwsCliEnvironment environment = new OktaAwsCliEnvironment(false, null, null, null, null, null, "https://acmecorp.oktapreview.com/home/amazon_aws/0oa5zrwfs815KJmVF0h7/137", null, 0, null, null, false, null);
         MenuHelper menuHelper = mock(MenuHelper.class);
         when(menuHelper.promptForMenuSelection(anyInt())).thenReturn(0);
         OktaFactorSelector factorSelector = new OktaFactorSelectorImpl(environment, menuHelper);


### PR DESCRIPTION
Problem Statement
-----------------
When using the Identity Provider (IdP) factor authentication ([Custom IdP Factor Authentication](https://help.okta.com/en/prod/Content/Topics/Security/MFA_Custom_Factor.htm)), there are additional SAML requests to the user authentication flow, which does not contain a relevant SAML assertion for parsing.


Solution
--------

Added an additional optional parameter ```OKTA_IGNORE_SAML_REQ_CONTAIN``` to allow users to skip specific URLs that contains a string.
