### PR TITLE
:bug: Fixes shell arguments being passed twice to aws command

### DIFF
--- a/bin/install.sh
+++ b/bin/install.sh
@@ -98,10 +98,10 @@ if ! grep '^#OktaAWSCLI' "${bash_functions}" &>/dev/null; then
     cat <<'EOF' >>"${bash_functions}"
 #OktaAWSCLI
 function okta-aws {
-    withokta "aws --profile $1" "$@"
+    withokta "aws --profile $1" "${@:2}"
 }
 function okta-sls {
-    withokta "sls --stage $1" "$@"
+    withokta "sls --stage $1" "${@:2}"
 }
 EOF
 fi
@@ -111,12 +111,12 @@ fishFunctionsDir="${PREFIX}/fish_functions"
 mkdir -p "${fishFunctionsDir}"
 cat <<'EOF' >"${fishFunctionsDir}/okta-aws.fish"
 function okta-aws
-    withokta "aws --profile $argv[1]" $argv
+    withokta "aws --profile $argv[1]" $argv[2..-1]
 end
 EOF
 cat <<'EOF' >"${fishFunctionsDir}/okta-sls.fish"
 function okta-sls
-    withokta "sls --stage $argv[1]" $argv
+    withokta "sls --stage $argv[1]" $argv[2..-1]
 end
 EOF
 


### PR DESCRIPTION
Removes first param from arg lists before calling aws cli. Fixes both bash and fish

Resolves: #375, #376

