### PR TITLE
Fix sms authentication, by checking verifyResponse

### DIFF
--- a/src/main/java/com/okta/tools/authentication/OktaMFA.java
+++ b/src/main/java/com/okta/tools/authentication/OktaMFA.java
@@ -284,7 +284,10 @@ public class OktaMFA {
         if (factorType.equals(FACTOR_TYPE_PUSH) && verifyResponse.has(LINKS)) {
             return handlePushPolling(profile, verifyResponse);
         } else {
-            return verifyResponse.getString(SESSION_TOKEN);
+            if (verifyResponse.has(SESSION_TOKEN)) {
+                return verifyResponse.getString(SESSION_TOKEN);
+            }
+            return "";
         }
     }
 


### PR DESCRIPTION
The first response for sms authentication doesn't have the session_token
in the response. Handle this case by testing for the SESSION_TOKEN in
the response before reading it.

Co-Authored-By: agopi@thumbtack.com

Signed-off-by: Anuj Varma <anujvarma@thumbtack.com>

Problem Statement
-----------------
https://github.com/oktadev/okta-aws-cli-assume-role/issues/382
https://github.com/oktadev/okta-aws-cli-assume-role/issues/349

Solution
--------
Handle the case by testing for the SESSION_TOKEN in
the response before reading it in the case of sms token where the reponse for verify removed the session_token.
https://developer.okta.com/docs/reference/api/authn/#verify-sms-factor
