### PR TITLE
Improve documentation on configuring AWS / Okta

### DIFF
--- a/Readme.MD
+++ b/Readme.MD
@@ -141,7 +141,9 @@ cp target/okta-aws-cli-*.jar ~/.okta/okta-aws-cli.jar
 
 ## Configuring AWS in Okta
 
-[Integrating the Amazon Web Services Command Line Interface Using Okta](https://support.okta.com/help/Documentation/Knowledge_Article/Integrating-the-Amazon-Web-Services-Command-Line-Interface-Using-Okta). 
+See for details on setting up [Amazon Web Services Account Federation](https://help.okta.com/en/prod/Content/Topics/DeploymentGuides/AWS/aws-deployment.htm) to allow logging into AWS through Okta and this tool.
+
+An alternative integration can be found in [Integrating the Amazon Web Services Command Line Interface Using Okta](https://support.okta.com/help/Documentation/Knowledge_Article/Integrating-the-Amazon-Web-Services-Command-Line-Interface-Using-Okta), which allows logging into AWS / Okta through the [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sso.html). The okta-aws-cli is _not_ compatible with this integration.
 
 ## Configuring the application
 Here is the list of parameters that can be environment variables or settings in the ```~/.okta/config.properties``` file:


### PR DESCRIPTION
Problem Statement
-----------------

The linked to docs in the README point towards setting up the AWS SSO integration, which does not work with this repo, as I discovered after wasting a handful of hours. This repo instead relies on the end-user having setup the AWS Federated integration, which is different, and does work with this tool.

Solution
--------

Improve the README, linking to the appropriate docs for this CLI to work, while also still linking to the original place, as it does offer an alternative approach in using the AWS CLI directly, which some people may prefer, but being clear that the two approaches are not equivalent and that this CLI will not work with both.
