### PR TITLE
Fix cookie support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
         <junit.jupiter.version>5.4.0</junit.jupiter.version>
         <ini4j.version>0.5.4</ini4j.version>
         <jsoup.version>1.14.2</jsoup.version>
-        <opensaml.version>3.4.5</opensaml.version>
+        <opensaml.version>3.4.6</opensaml.version>
         <slf4j.version>1.7.26</slf4j.version>
         <openjfx.version>12.0.1</openjfx.version>
     </properties>

--- a/src/main/java/com/okta/tools/authentication/BrowserAuthentication.java
+++ b/src/main/java/com/okta/tools/authentication/BrowserAuthentication.java
@@ -103,7 +103,7 @@ public final class BrowserAuthentication extends Application {
 
     private void initializeCookies(URI uri) throws IOException {
         Map<String, List<String>> headers = cookieHelper.loadCookieHeaders();
-        java.net.CookieHandler.setDefault(new CookieManager(cookieHelper));
+        java.net.CookieHandler.setDefault(new CookieManager(cookieHelper, uri));
         java.net.CookieHandler.getDefault().put(uri, headers);
     }
 

--- a/src/main/java/com/okta/tools/authentication/CookieManager.java
+++ b/src/main/java/com/okta/tools/authentication/CookieManager.java
@@ -29,9 +29,11 @@ import java.util.Map;
 public final class CookieManager extends CookieHandler {
     private final CookieHandler cookieHandler = CookieHandler.getDefault();
     private final CookieHelper cookieHelper;
+    private final String targetDomain;
 
-    public CookieManager(CookieHelper cookieHelper) {
+    public CookieManager(CookieHelper cookieHelper, URI targetUri) {
         this.cookieHelper = cookieHelper;
+        this.targetDomain = targetUri.getHost();
     }
 
     @Override
@@ -42,7 +44,9 @@ public final class CookieManager extends CookieHandler {
 
     @Override
     public void put(URI uri, Map<String,List<String>> responseHeaders) throws IOException {
-        cookieHelper.storeCookies(responseHeaders);
+        if (uri.getAuthority().equals(targetDomain)) {
+            cookieHelper.storeCookies(responseHeaders);
+        }
         cookieHandler.put(uri, responseHeaders);
     }
 }

--- a/src/main/java/com/okta/tools/helpers/CookieHelper.java
+++ b/src/main/java/com/okta/tools/helpers/CookieHelper.java
@@ -15,6 +15,7 @@
  */
 package com.okta.tools.helpers;
 
+import com.google.common.collect.Iterables;
 import com.okta.tools.OktaAwsCliEnvironment;
 import org.apache.http.Header;
 import org.apache.http.NameValuePair;
@@ -127,7 +128,10 @@ public final class CookieHelper {
     }
 
     public void storeCookies(Map<String, List<String>> responseHeaders) throws IOException {
-        responseHeaders.getOrDefault(SET_COOKIE_HEADER_NAME, Collections.emptyList()).forEach(cookie ->
+        Iterables.concat(
+                responseHeaders.getOrDefault(SET_COOKIE_HEADER_NAME.toLowerCase(), Collections.emptyList()),
+                responseHeaders.getOrDefault(SET_COOKIE_HEADER_NAME, Collections.emptyList()))
+                .forEach(cookie ->
                 cookieHeaders.put(cookie.substring(0, cookie.indexOf('=')), cookie)
         );
         Files.write(


### PR DESCRIPTION
Problem Statement
-----------------
All cookies seen are stored in disk. Cookies name can clash between sites causing the OKTA cookies to be overwritten. 

Solution
--------
Filter cookies to be stored by host.

